### PR TITLE
allow server opa command to be customized

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenPolicyAgent"
 uuid = "8f257efb-743c-4ebc-8197-d291a1f743b4"
 authors = ["JuliaHub Inc.", "Tanmay Mohapatra <tanmaykm@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/server/server.jl
+++ b/src/server/server.jl
@@ -31,6 +31,7 @@ struct MonitoredOPAServer
     port::Int
     stdout::Any
     stderr::Any
+    cmdline::CommandLine
     monitor_task::Ref{Union{Nothing, Task}}
     server_proc::Ref{Union{Nothing, Process}}
     stopped::Ref{Bool}
@@ -41,10 +42,17 @@ struct MonitoredOPAServer
         port::Int = DEFAULT_PORT,
         stdout = nothing,
         stderr = nothing,
+        cmdline = nothing,
     )
+        if isnothing(cmdline)
+            cmdline = CommandLine()
+        end
+        cmdline.runopts[:wait] = false
+
         return new(configfile,
             host, port,
             stdout, stderr,
+            cmdline,
             Ref{Union{Nothing, Task}}(nothing),
             Ref{Union{Nothing, Process}}(nothing),
             Ref{Bool}(true),
@@ -54,8 +62,7 @@ struct MonitoredOPAServer
 end
 
 function start_opa_server!(server::MonitoredOPAServer)
-    ctx = CommandLine()
-    ctx.runopts[:wait] = false
+    ctx = server.cmdline
     if !isnothing(server.stdout)
         ctx.pipelineopts[:stdout] = server.stdout
     end


### PR DESCRIPTION
Allow the opa command that the server runs to be fully customized. Primarily to enable running a custom opa server build.