### PR TITLE
tests: accept AbstractDict for compatibility with JSON.jl v1

### DIFF
--- a/src/utils/ast.jl
+++ b/src/utils/ast.jl
@@ -142,7 +142,7 @@ function after(visitor::ASTVisitor, node)
     return pop!(visitor.result_stack) # either a QuerySet or nothing
 end
 
-function _visit(visitor::ASTVisitor, ::Type{QuerySet}, node::Dict{String,Any})
+function _visit(visitor::ASTVisitor, ::Type{QuerySet}, node::AbstractDict)
     if haskey(node, "queries") && length(node["queries"]) > 0
         data = node["queries"]
         N = length(data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,11 +91,11 @@ function test_config_api(openapi_client)
     @test length(services) == 1
     @test services[1]["name"] == "BundleServiceAPI"
 
-    @test haskey(result, "bundles") && isa(result["bundles"], Dict)
+    @test haskey(result, "bundles") && isa(result["bundles"], AbstractDict)
     bundles = result["bundles"]
     @test Set(keys(bundles)) == Set(["data", "policies"])
 
-    @test haskey(result, "keys") && isa(result["keys"], Dict)
+    @test haskey(result, "keys") && isa(result["keys"], AbstractDict)
     bundle_keys = result["keys"]
     @test haskey(bundle_keys, "bundle_key")
     @test haskey(bundle_keys["bundle_key"], "algorithm")

--- a/test/sql_translate.jl
+++ b/test/sql_translate.jl
@@ -267,7 +267,7 @@ function to_sql(queryset::QuerySet)
     end
 end
 
-function translate(result::Dict{String, Any})
+function translate(result::AbstractDict)
     if haskey(result, "queries") && length(result["queries"]) > 0
         return to_sql(from_data(QuerySet, result["queries"]))
     else


### PR DESCRIPTION
## Summary

JSON.jl v1 parses JSON objects into `JSON.Object{String,Any}` rather than `Dict{String,Any}`. Several method signatures were restricted to `Dict{String,Any}`, so OPA partial-compile results (which are JSON-parsed) no longer matched on current Julia — breaking the Config API and Compile API testsets. The suite still passed on Julia 1.6, which resolves an older JSON.jl that returns `Dict`, which is why this only surfaced recently.

## Changes

Widen the affected signatures to `AbstractDict` (`JSON.Object <: AbstractDict`):

- `src/utils/ast.jl` — the `QuerySet` AST-walk entry point `_visit(::ASTVisitor, ::Type{QuerySet}, node)`. This is production code, so consumers passing JSON.Object-typed partial-compile results now work.
- `test/sql_translate.jl` — the standalone reference translator's `translate()`.
- `test/runtests.jl` — two `isa(..., Dict)` assertions in the Config API testset.

## Verification

Full suite passes (155/155) on current Julia with JSON v1.6.1.
